### PR TITLE
Fix misspelled argument that breaks shape output.

### DIFF
--- a/clsDXFTools.py
+++ b/clsDXFTools.py
@@ -697,7 +697,7 @@ def EineDXF(uiParent, mLay_crs, bZielSave, sOutForm, grpProjekt,AktList, Kern, A
 
         try:
             if sOutForm == "SHP":
-                opt = ('-skipfailure %s -nlt %s %s -sql "select *, ogr_style from entities where OGR_GEOMETRY %s"') % (AktOpt,v[1],optGCP,v[2])      
+                opt = ('-skipfailures %s -nlt %s %s -sql "select *, ogr_style from entities where OGR_GEOMETRY %s"') % (AktOpt,v[1],optGCP,v[2])      
                 if bGen3D:
                     opt = opt +  ' -dim 3 '
 


### PR DESCRIPTION
The proper option name is -skipfailures.  
The importer was failing when outputting to shapes because of Unknown Argument "-skipfailure" to ogr2ogr