### PR TITLE
Added a paste function for georeferencing points

### DIFF
--- a/uiADXF2Shape.ui
+++ b/uiADXF2Shape.ui
@@ -563,44 +563,54 @@
           </layout>
          </item>
          <item row="0" column="1">
-          <widget class="QTableWidget" name="tabTPoints">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="rowCount">
-            <number>4</number>
-           </property>
-           <property name="columnCount">
-            <number>4</number>
-           </property>
-           <row/>
-           <row/>
-           <row/>
-           <row/>
-           <column>
-            <property name="text">
-             <string>ungeoref X</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>ungeoref Y</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>georef X</string>
-            </property>
-           </column>
-           <column>
-            <property name="text">
-             <string>georef Y</string>
-            </property>
-           </column>
-          </widget>
+          <layout class="QVBoxLayout" name="verticalLayout_points">
+            <item>
+              <widget class="QTableWidget" name="tabTPoints">
+                <property name="sizePolicy">
+                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                  </sizepolicy>
+                </property>
+                <property name="rowCount">
+                  <number>4</number>
+                </property>
+                <property name="columnCount">
+                  <number>4</number>
+                </property>
+                <row/>
+                <row/>
+                <row/>
+                <row/>
+                <column>
+                  <property name="text">
+                  <string>ungeoref X</string>
+                  </property>
+                </column>
+                <column>
+                  <property name="text">
+                  <string>ungeoref Y</string>
+                  </property>
+                </column>
+                <column>
+                  <property name="text">
+                  <string>georef X</string>
+                  </property>
+                </column>
+                <column>
+                  <property name="text">
+                  <string>georef Y</string>
+                  </property>
+                </column>
+              </widget>
+            </item>
+            <item>
+            <widget class="QPushButton" name="btnPastePoints">
+              <property name="text">
+                <string>Paste point pairs from clipboard</string>
+              </property>
+            </item>
+          </layout>
          </item>
         </layout>
        </item>

--- a/uiADXF2Shape.ui
+++ b/uiADXF2Shape.ui
@@ -605,10 +605,11 @@
               </widget>
             </item>
             <item>
-            <widget class="QPushButton" name="btnPastePoints">
-              <property name="text">
-                <string>Paste point pairs from clipboard</string>
-              </property>
+              <widget class="QPushButton" name="btnPastePoints">
+                <property name="text">
+                  <string>Paste point pairs from clipboard</string>
+                </property>
+              </widget>
             </item>
           </layout>
          </item>


### PR DESCRIPTION
Added in a paste function so you can copy in the cross referencing points, expects the table order to be the same as the table shown in the ui- 
ungeo x, ungeo y, geo x, geo y

(Will filter out the header if that is copied too)
