### PR TITLE
Refactor clsDBase.py to handle QGIS expectations for hex values

### DIFF
--- a/clsDBase.py
+++ b/clsDBase.py
@@ -473,7 +473,15 @@ def attTableEdit (sOutForm, inpDat,bFormat,sCharSet,gpkgTable=None, txtErsatz4Ta
                     if len(arr) == 2:
                         f = arr[0] 
                         w = arr[1]
-
+                        
+                        def replaceColour(colour): #QGIS expects #AARRGGBB, but hex is usually #RRGGBBAA, so need to swap the start.
+                            if (len(colour) == 9 and colour[:1]== '#':
+                                return '#' + colour[7:9] + colour[1:7]
+                            else:
+                                return colour
+                        
+                        f = replaceColour(f)
+                        w = replaceColour(w)
 
                         if f == "c":
 
@@ -591,4 +599,5 @@ def attTableEdit (sOutForm, inpDat,bFormat,sCharSet,gpkgTable=None, txtErsatz4Ta
             feature = layer.GetNextFeature()
     layer.CommitTransaction()
     source.Destroy()
+
 


### PR DESCRIPTION
Handling of the hex colours to suit QGIS - Which expects colour to appear as #AARRGGBB rather than #RRGGBBAA.